### PR TITLE
Maintenance

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.13", "pypy-3.9", "pypy-3.10"]
+        python-version: ["3.9", "3.13", "3.14.0-beta.4", "pypy-3.9", "pypy-3.10", "pypy-3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ $RECYCLE.BIN/
 *.msi
 *.msm
 *.msp
+
+# Test coverage tmp files
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -57,11 +58,7 @@ filterwarnings = [
 [tool.ruff]
 line-length = 88
 
-[tool.black]
-line-length = 88
-
 [tool.isort]
 # This forces these imports to placed at the top
 known_future_library = ["typing"]
-profile = "black"
 line_length = 88

--- a/src/icegrams/__init__.py
+++ b/src/icegrams/__init__.py
@@ -1,43 +1,51 @@
 """
 
-    Icegrams: A trigrams library for Icelandic
+Icegrams: A trigrams library for Icelandic
 
-    __init__.py
+__init__.py
 
-    Copyright (C) 2024 Miðeind ehf.
-    Original author: Vilhjálmur Þorsteinsson
+Copyright (C) 2019-2025 Miðeind ehf.
+Original author: Vilhjálmur Þorsteinsson
 
-    This software is licensed under the MIT License:
+This software is licensed under the MIT License:
 
-        Permission is hereby granted, free of charge, to any person
-        obtaining a copy of this software and associated documentation
-        files (the "Software"), to deal in the Software without restriction,
-        including without limitation the rights to use, copy, modify, merge,
-        publish, distribute, sublicense, and/or sell copies of the Software,
-        and to permit persons to whom the Software is furnished to do so,
-        subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge,
+    publish, distribute, sublicense, and/or sell copies of the Software,
+    and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
 
-        The above copyright notice and this permission notice shall be
-        included in all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
 
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-        IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-        CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-        TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-        SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-    This module exposes the icegrams API, i.e. the identifiers that are
-    directly accessible via the icegrams module object after importing it.
+This module exposes the icegrams API, i.e. the identifiers that are
+directly accessible via the icegrams module object after importing it.
 
 """
 
 import importlib.metadata
 
 __author__ = "Miðeind ehf."
-__copyright__ = "(C) 2020-2024 Miðeind ehf."
+__copyright__ = "(C) 2019-2025 Miðeind ehf."
 __version__ = importlib.metadata.version("icegrams")
 
 # Expose the icegrams API
 from .ngrams import Ngrams, MAX_ORDER
+
+__all__ = [
+    "Ngrams",
+    "MAX_ORDER",
+    "__author__",
+    "__copyright__",
+    "__version__",
+]

--- a/src/icegrams/trie_build.py
+++ b/src/icegrams/trie_build.py
@@ -1,38 +1,38 @@
 """
 
-    Icegrams: A trigrams library for Icelandic
+Icegrams: A trigrams library for Icelandic
 
-    CFFI builder for _trie module
+CFFI builder for _trie module
 
-    Copyright (C) 2024 Miðeind ehf.
-    Original author: Vilhjálmur Þorsteinsson
+Copyright (C) 2019-2025 Miðeind ehf.
+Original author: Vilhjálmur Þorsteinsson
 
-    This software is licensed under the MIT License:
+This software is licensed under the MIT License:
 
-        Permission is hereby granted, free of charge, to any person
-        obtaining a copy of this software and associated documentation
-        files (the "Software"), to deal in the Software without restriction,
-        including without limitation the rights to use, copy, modify, merge,
-        publish, distribute, sublicense, and/or sell copies of the Software,
-        and to permit persons to whom the Software is furnished to do so,
-        subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge,
+    publish, distribute, sublicense, and/or sell copies of the Software,
+    and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
 
-        The above copyright notice and this permission notice shall be
-        included in all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
 
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-        IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-        CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-        TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-        SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-    This module only runs at setup/installation time. It is invoked
-    from setup.py as requested by the cffi_modules=[] parameter of the
-    setup() function. It causes the _trie.*.so CFFI wrapper library
-    to be built from its source in trie.cpp.
+This module only runs at setup/installation time. It is invoked
+from setup.py as requested by the cffi_modules=[] parameter of the
+setup() function. It causes the _trie.*.so CFFI wrapper library
+to be built from its source in trie.cpp.
 
 """
 


### PR DESCRIPTION
* Explicitly supporting Python 3.14
* Updated CI test matrix
* Switched to ruff for linting and formatting
* Fixed various minor linter complaints
* Explicit package exports via __all__

NB: More to come, but serious changes shouldn't be lost in the linter reformatting