### PR TITLE
Publish abi3 wheels; fix C++ linking in source builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "icegrams"
-version = "1.1.6"
+version = "1.1.7"
 description = "Trigram statistics for Icelandic"
 authors = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]
 maintainers = [{ name = "Miðeind ehf.", email = "mideind@mideind.is" }]

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python3
 
+import platform
 from glob import glob
 from os.path import basename, splitext
 
 from setuptools import find_packages, setup
+
+# Use the stable ABI (abi3) for CPython to create portable wheels that work
+# across Python versions (3.9+). PyPy doesn't support the stable ABI, so we
+# create version-specific wheels for it. This must match the py_limited_api
+# setting in src/icegrams/trie_build.py.
+options: dict[str, str] = {}
+if platform.python_implementation() == "CPython":
+    options["py_limited_api"] = "cp39"
 
 setup(
     packages=find_packages("src"),
@@ -15,4 +24,5 @@ setup(
     setup_requires=["cffi>=1.15.1", "setuptools"],
     install_requires=["cffi>=1.15.1"],
     cffi_modules=["src/icegrams/trie_build.py:ffibuilder"],
+    options={"bdist_wheel": options},
 )

--- a/src/icegrams/trie_build.py
+++ b/src/icegrams/trie_build.py
@@ -108,9 +108,15 @@ else:
     extra_compile_args = ["-std=c++11"]
 
 # On some systems, the linker needs to be told to use the C++ compiler
-# under PyPy due to changes in the default behaviour of distutils.
+# due to changes in the default behaviour of distutils/setuptools.
+# Otherwise the extension may be linked with the C driver, omitting
+# libstdc++ and failing at import time with
+# "undefined symbol: __gxx_personality_v0".
 if IMPLEMENTATION == "PyPy":
     os.environ["LDCXXSHARED"] = "c++ -shared"
+elif not WINDOWS and not MACOS:
+    os.environ.setdefault("LDSHARED", "c++ -shared")
+    os.environ.setdefault("LDCXXSHARED", "c++ -shared")
 
 # Use the Python stable ABI (abi3) for CPython, allowing a single wheel
 # to work across multiple Python versions (3.9+). PyPy doesn't support abi3.


### PR DESCRIPTION
## Problem

Published wheels are tagged `cp39-cp39` (CPython 3.9 only), despite the abi3 intent in `trie_build.py` and the CI comments. Every consumer on Python 3.10+ therefore compiles icegrams from the sdist. Recent setuptools links C++ extensions with the C driver, omitting `libstdc++`, so those source builds now fail at import time with `undefined symbol: __gxx_personality_v0` (seen in Docker deploys on `python:3.14-slim`).

## Changes

- `setup.py`: pass `py_limited_api = "cp39"` to `bdist_wheel` on CPython (mirrors BinPackage), so cibuildwheel produces a single `cp39-abi3` wheel covering CPython 3.9+.
- `trie_build.py`: extend the existing PyPy linker workaround to Linux CPython source builds, forcing the C++ link driver so `libstdc++` is always linked.
- Version bump to 1.1.7.

## Verification

Built locally: wheel comes out `icegrams-1.1.7-cp39-abi3-macosx_15_0_arm64.whl` (previously `cp39-cp39`). Installed that wheel into a Python **3.14** venv: import succeeds and trigram lookups work.